### PR TITLE
In env.sh, set ROS_HOSTNAME to automatically use "`hostname`.local"

### DIFF
--- a/cmake/templates/env.sh.in
+++ b/cmake/templates/env.sh.in
@@ -7,6 +7,8 @@ if [ $# -eq 0 ] ; then
   exit 1
 fi
 
+export ROS_HOSTNAME="`hostname`.local"
+
 # ensure to not use different shell type which was set before
 CATKIN_SHELL=sh
 


### PR DESCRIPTION
I think it would be useful to add the following to `env.sh.in`.

Use case :
If the `<node>` tag in the `.launch` file is used with the machine option, the remote machine will specify `env.sh` as the `env-loader`, but since this file is auto-generated by catkin, it will be erased by `catkin clean`. However, this file is automatically generated by catkin, so it will be deleted by `catkin clean`.
The minimum value that must be specified in `env.sh` is `ROS_HOSTNAME`. (In my environment, `ROS_MASTER_URI` is not necessary.)
So, it would be useful if `ROS_HOSTNAME` contains a valid default value.
How about using the ".local" address, which is made available by `avahi-daemon`, a commonly used mdns?

I'm new to ROS, so I may not understand the concept of ROS as well as I should. Please point out any mistakes in what I wrote above.
Thank you very much.